### PR TITLE
Use currently-recommended URLs

### DIFF
--- a/wavedrom.php
+++ b/wavedrom.php
@@ -9,8 +9,8 @@ class WaveDrom {
                   // Render <wavedrom>
   public static function renderTagWavedrom( $input, array $args, Parser $parser, PPFrame $frame ) {
     //$parser->addHeadItem(
-    $parser->getOutput()->addHeadItem('<script src="http://wavedrom.com/skins/default.js" type="text/javascript"></script>', 'WaveDromDefault');
-    $parser->getOutput()->addHeadItem('<script src="http://wavedrom.com/wavedrom.min.js" type="text/javascript"></script>', 'WaveDromMain');
+    $parser->getOutput()->addHeadItem('<script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/2.6.8/skins/default.js" type="text/javascript"></script>', 'WaveDromDefault');
+    $parser->getOutput()->addHeadItem('<script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/2.6.8/wavedrom.min.js" type="text/javascript"></script>', 'WaveDromMain');
     $parser->getOutput()->addHeadItem('<script>window.addEventListener(\'DOMContentLoaded\', WaveDrom.ProcessAll, false);</script>', 'WaveDromLoad');
     // Mediawiki add <p> and <pre> if newlines ...
     $inputstriped = str_replace(array("\n", "\r"), "", $input);


### PR DESCRIPTION
The MediaWiki wavedrom module points at http://wavedrom.com, whereas the wavedrom README says to use https://cdnjs.cloudflare.com, e.g.:

<script src="http://wavedrom.com/skins/default.js" type="text/javascript"></script>
<script src="http://wavedrom.com/wavedrom.min.js" type="text/javascript"></script>

should be:

<script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/2.6.8/skins/default.js" type="text/javascript"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/2.6.8/wavedrom.min.js" type="text/javascript"></script>